### PR TITLE
feat: Shared global Semantic PR config for MeltanoLabs

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,28 @@
+# This is a default config file for the Semantic PRs GitHub App for the MeltanoLabs GitHub org.
+#
+# Notes:
+#
+# - Config syntax: https://github.com/Ezard/semantic-prs
+# - If a repo has their own `semantic.yml` config file, that file will be used instead of this one.
+#   - See https://github.com/Ezard/semantic-prs/issues/227 for more info.
+
+# Validate the PR title, and ignore all commit messages
+titleOnly: true
+
+# Provides a custom URL for the "Details" link, which appears next to the success/failure message from the app:
+targetUrl: https://sdk.meltano.com/en/latest/CONTRIBUTING.html#semantic-pull-requests
+
+# The values allowed for the "type" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"
+types:
+  - ci
+  - chore
+  - build
+  - docs
+  - feat
+  - fix
+  - perf
+  - refactor
+  - revert
+  - style
+  - test


### PR DESCRIPTION
Adds a simple default config for Semantic PRs GitHub App, which is now enabled for all repos in `MeltanoLabs`.

Related to:

- https://github.com/MeltanoLabs/Meta/pull/33
- https://github.com/Ezard/semantic-prs/issues/227
